### PR TITLE
feat(socket): dynamically send namespaces data from the server on client connection

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -5,13 +5,9 @@
 
 <div class="container-fluid">
   <div class="row">
+    <!-- This will be update dynamically -->
     <div class="namespaces">
-      <div class="namespace" ns="/wiki"><img
-          src="https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/103px-Wikipedia-logo-v2.svg.png">
-      </div>
-      <div class="namespace" ns="/mozilla"><img
-          src="https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png"></div>
-      <div class="namespace" ns="/linux"><img src="https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png"></div>
+      
     </div>
     <div class="rooms">
       <div class="main-rooms">

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -1,24 +1,24 @@
 const socket = io('http://localhost:8000'); // the / (main) namespace
-// const socket2 = io('http://localhost:8000/admin'); // the /admin namespace
-const socket2 = io('http://localhost:8000/wiki');
-const socket3 = io('http://localhost:8000/mozilla');
-const socket4 = io('http://localhost:8000/linux');
+
+// Listen for namespaceList event, list all namespaces.
+socket.on("namespaceList", (namespaceData) => {
+  console.log("The list of namespaces has arrived!!");
+  // console.log(namespaceData);
+  let namespacesDiv = document.querySelector(".namespaces");
+  namespacesDiv.innerHTML = "";
+  namespaceData.forEach((ns) => {
+    namespacesDiv.innerHTML += `<div class="namespace"><img src="${ns.img}" /></div>`;
+  });
+});
 
 socket.on("messageFromServer", (dataFromServer) => {
   console.log(dataFromServer);
   socket.emit("dataToServer", {data: "Data from the client!"});
 });
 
-socket.on("joined", (msg) => {
-  console.log(msg); 
-});
+// document.querySelector("#message-form").addEventListener("submit", (event) => {
+//   event.preventDefault();
+//   const newMessage = document.querySelector("#user-message").value;
+//   socket.emit("newMessageToServer", {text: newMessage});
+// });
 
-socket2.on("welcome", (dataFromServer) => {
-  console.log(dataFromServer);
-});
-
-document.querySelector("#message-form").addEventListener("submit", (event) => {
-  event.preventDefault();
-  const newMessage = document.querySelector("#user-message").value;
-  socket.emit("newMessageToServer", {text: newMessage});
-});

--- a/slack.js
+++ b/slack.js
@@ -11,12 +11,17 @@ const expressServer = app.listen(8000);
 const io = socketio(expressServer);
 
 io.on("connection", (socket) => {
-  socket.emit("messageFromServer", {data: "Welcome to the SocketIO server!"});
-  socket.on('dataToServer', (dataFromClient) => {
-    console.log(dataFromClient);
+  // build an array to send back info with the img and endpoint for each NS
+  let namespaceData = namespaces.map((ns) => {
+    return {
+      img: ns.img,
+      endpoint: ns.endpoint,
+    }
   });
-  socket.join("level1");
-  socket.to("level1").emit("joined", `${socket.id}: I have joined the level one room`);
+  // console.log(namespaceData);
+  // ! Send the namespaceData back to the client, we'll socket and not io
+  // ! because we only want to send the data to this client (socket).
+  socket.emit("namespaceList", namespaceData);
 });
 
 // loop through each namespace and look for a connection


### PR DESCRIPTION
Previously, I had hardcoded namespaces (workspaces in Slack lingo) with their images, removed it and instead added the functionality where the server would send data to the client upon connection.